### PR TITLE
Fix iOS countdown error

### DIFF
--- a/src/components/Countdown.tsx
+++ b/src/components/Countdown.tsx
@@ -4,7 +4,7 @@ import "./Countdown.css";
 export const Countdown = () => {
   const getCountdown = () => {
     const timeRemaining =
-      new Date(`2022-11-1`).getTime() - new Date().getTime();
+      new Date(`2022-11-01`).getTime() - new Date().getTime();
     let countdown = {};
     if (timeRemaining > 0) {
       countdown = {


### PR DESCRIPTION
Fixes #3

Seems as if 2022-11-1 (NaN) is not a valid date according to Apple WebKit (which is used for Chrome on iOS as well)

Remote debugging and changing date to 2022-11-01 fixes it.

![C2812ED1-E73A-441F-9AED-91B22EC0B45F](https://user-images.githubusercontent.com/17863113/116614783-ab2d4480-a93a-11eb-9950-b5f9eeba3614.jpeg)